### PR TITLE
Update config.yml links for community support, FAQ

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
     - name: Runestone Community Support
-      url: https://runestoneinteractive.org/pages/support.html
+      url: https://blog.runestone.academy/pages/support.html
       about: Our slack channel is the best place to get immediate support for questions
     - name: Frequently Asked Questions
-      url: https://runestoneinteractive.org/pages/faq.html
+      url: https://blog.runestone.academy/pages/faq.html
       about: Please Check here before asking a question or creating an issue


### PR DESCRIPTION
Links for community support for the slack channels and FAQs were outdated. Hence, replaced them with the new working links. 
Support: https://blog.runestone.academy/pages/support.html
FAQs: https://blog.runestone.academy/pages/faq.html